### PR TITLE
Adjust home screen ads and promos

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeViewModel.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeViewModel.java
@@ -34,20 +34,25 @@ public class HomeViewModel extends AndroidViewModel {
         dailyTip.setValue(homeRepository.getDailyTip());
 
         promotedApps.add(new PromotedApp(
-                R.mipmap.ic_shortcut_kotlin_edition,
-                R.string.kotlin_edition_name,
-                R.string.kotlin_edition_description,
-                application.getString(R.string.package_ast_kotlin)));
-        promotedApps.add(new PromotedApp(
                 R.drawable.ic_shop,
                 R.string.cart_calculator_name,
                 R.string.cart_calculator_description,
-                application.getString(R.string.package_cart_calculator)));
+                application.getString(R.string.package_cart_calculator));
         promotedApps.add(new PromotedApp(
                 R.drawable.ic_safety_check_tinted,
                 R.string.cleaner_android_name,
                 R.string.cleaner_android_description,
-                application.getString(R.string.package_cleaner_android)));
+                application.getString(R.string.package_cleaner_android));
+        promotedApps.add(new PromotedApp(
+                R.drawable.ic_build_tinted,
+                R.string.apptoolkit_android_name,
+                R.string.apptoolkit_android_description,
+                application.getString(R.string.package_apptoolkit_android));
+        promotedApps.add(new PromotedApp(
+                R.drawable.ic_code,
+                R.string.qr_scanner_name,
+                R.string.qr_scanner_description,
+                application.getString(R.string.package_qr_scanner));
     }
 
     /**

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -188,13 +188,21 @@
 
                     <com.google.android.material.button.MaterialButton
                         android:id="@+id/share_tip_button"
-                        style="@style/Widget.Material3.Button.Icon"
+                        style="@style/Widget.Material3.Button.IconButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:contentDescription="@string/share"
                         app:icon="@drawable/ic_share" />
                 </androidx.appcompat.widget.LinearLayoutCompat>
             </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.gms.ads.AdView
+                android:id="@+id/small_banner_ad"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                app:adSize="MEDIUM_RECTANGLE"
+                app:adUnitId="@string/ad_banner_unit_id" />
 
             <com.airbnb.lottie.LottieAnimationView
                 android:id="@+id/learningAnimation"
@@ -225,14 +233,6 @@
                     tools:ignore="ImageContrastCheck" />
             </com.google.android.material.card.MaterialCardView>
 
-            <com.google.android.gms.ads.AdView
-                android:id="@+id/small_banner_ad"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_alignParentBottom="true"
-                android:layout_marginTop="16dp"
-                app:adSize="MEDIUM_RECTANGLE"
-                app:adUnitId="@string/ad_banner_unit_id" />
         </androidx.appcompat.widget.LinearLayoutCompat>
     </me.zhanghai.android.fastscroll.FastScrollScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,7 +16,7 @@
     <string name="main_card_title">Discover Android Studio Tutorials</string>
     <string name="main_card_subtitle">Featuring Kotlin and Java Editions</string>
     <string name="main_card_description">The Kotlin Edition has been updated with dynamic lessons, AI assistant, and more. Experience the future of Android development!</string>
-    <string name="get_on_google_play">Get it on Google Play</string>
+    <string name="get_on_google_play">Google Play</string>
 
     <string name="android_studio">Android Studio</string>
 
@@ -411,4 +411,8 @@
     <string name="cart_calculator_description">Quickly total up your shopping cart.</string>
     <string name="cleaner_android_name">Cleaner for Android</string>
     <string name="cleaner_android_description">Free up space and optimize your device.</string>
+    <string name="apptoolkit_android_name">AppToolkit for Android</string>
+    <string name="apptoolkit_android_description">Handy utilities for managing your apps.</string>
+    <string name="qr_scanner_name">QR &amp; Barcode Scanner</string>
+    <string name="qr_scanner_description">Fast and secure scanning.</string>
 </resources>

--- a/app/src/main/res/values/untranslatable_strings.xml
+++ b/app/src/main/res/values/untranslatable_strings.xml
@@ -47,4 +47,6 @@
     <string name="package_ast_kotlin" translatable="false">com.d4rk.androidtutorials</string>
     <string name="package_cart_calculator" translatable="false">com.d4rk.cartcalculator</string>
     <string name="package_cleaner_android" translatable="false">com.d4rk.cleaner</string>
+    <string name="package_apptoolkit_android" translatable="false">com.d4rk.apptoolkit</string>
+    <string name="package_qr_scanner" translatable="false">com.d4rk.qrscanner</string>
 </resources>


### PR DESCRIPTION
## Summary
- place small banner ad above the learning animation on the home screen
- style the share tip button as an icon button
- shorten "Get it on Google Play" text
- add AppToolkit and QR Scanner to promoted apps
- update package list for promoted apps

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849767c1448832da943b0185c0d461f