### PR TITLE
Add rotating promotions from remote list

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/data/model/PromotedApp.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/data/model/PromotedApp.java
@@ -1,11 +1,17 @@
 package com.d4rk.androidtutorials.java.data.model;
 
-import androidx.annotation.DrawableRes;
-import androidx.annotation.StringRes;
+/**
+ * Model representing a promoted application fetched from the remote API.
+ */
+public class PromotedApp {
 
-public record PromotedApp(
-        @DrawableRes int iconResId,
-        @StringRes int nameResId,
-        @StringRes int descriptionResId,
-        String packageName
-) {}
+    public final String name;
+    public final String packageName;
+    public final String iconUrl;
+
+    public PromotedApp(String name, String packageName, String iconUrl) {
+        this.name = name;
+        this.packageName = packageName;
+        this.iconUrl = iconUrl;
+    }
+}

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeFragment.java
@@ -66,14 +66,29 @@ public class HomeFragment extends Fragment {
 
     private void setupPromotions(LayoutInflater inflater) {
         ViewGroup container = binding.promotedAppsContainer;
-        for (com.d4rk.androidtutorials.java.data.model.PromotedApp app : homeViewModel.getPromotedApps()) {
-            com.d4rk.androidtutorials.java.databinding.PromotedAppItemBinding itemBinding =
-                    com.d4rk.androidtutorials.java.databinding.PromotedAppItemBinding.inflate(inflater, container, false);
-            itemBinding.appIcon.setImageResource(app.iconResId());
-            itemBinding.appName.setText(app.nameResId());
-            itemBinding.appDescription.setText(app.descriptionResId());
-            itemBinding.appButton.setOnClickListener(v -> startActivity(homeViewModel.getPromotedAppIntent(app.packageName())));
-            container.addView(itemBinding.getRoot());
-        }
+        homeViewModel.getPromotedApps().observe(getViewLifecycleOwner(), apps -> {
+            container.removeAllViews();
+            for (com.d4rk.androidtutorials.java.data.model.PromotedApp app : apps) {
+                com.d4rk.androidtutorials.java.databinding.PromotedAppItemBinding itemBinding =
+                        com.d4rk.androidtutorials.java.databinding.PromotedAppItemBinding.inflate(inflater, container, false);
+                loadImage(app.iconUrl, itemBinding.appIcon);
+                itemBinding.appName.setText(app.name);
+                itemBinding.appDescription.setVisibility(android.view.View.GONE);
+                itemBinding.appButton.setOnClickListener(v -> startActivity(homeViewModel.getPromotedAppIntent(app.packageName)));
+                container.addView(itemBinding.getRoot());
+            }
+        });
+    }
+
+    private void loadImage(String url, android.widget.ImageView imageView) {
+        com.android.volley.toolbox.ImageRequest request = new com.android.volley.toolbox.ImageRequest(
+                url,
+                imageView::setImageBitmap,
+                0,
+                0,
+                android.widget.ImageView.ScaleType.CENTER_INSIDE,
+                android.graphics.Bitmap.Config.ARGB_8888,
+                error -> {});
+        com.android.volley.toolbox.Volley.newRequestQueue(requireContext()).add(request);
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeViewModel.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeViewModel.java
@@ -23,7 +23,7 @@ public class HomeViewModel extends AndroidViewModel {
     private final MutableLiveData<String> announcementTitle = new MutableLiveData<>();
     private final MutableLiveData<String> announcementSubtitle = new MutableLiveData<>();
     private final MutableLiveData<String> dailyTip = new MutableLiveData<>();
-    private final List<PromotedApp> promotedApps = new ArrayList<>();
+    private final MutableLiveData<List<PromotedApp>> promotedApps = new MutableLiveData<>(new ArrayList<>());
 
     public HomeViewModel(@NonNull Application application) {
         super(application);
@@ -33,26 +33,18 @@ public class HomeViewModel extends AndroidViewModel {
         announcementSubtitle.setValue(application.getString(R.string.announcement_subtitle));
         dailyTip.setValue(homeRepository.getDailyTip());
 
-        promotedApps.add(new PromotedApp(
-                R.drawable.ic_shop,
-                R.string.cart_calculator_name,
-                R.string.cart_calculator_description,
-                application.getString(R.string.package_cart_calculator)));
-        promotedApps.add(new PromotedApp(
-                R.drawable.ic_safety_check_tinted,
-                R.string.cleaner_android_name,
-                R.string.cleaner_android_description,
-                application.getString(R.string.package_cleaner_android)));
-        promotedApps.add(new PromotedApp(
-                R.drawable.ic_build_tinted,
-                R.string.apptoolkit_android_name,
-                R.string.apptoolkit_android_description,
-                application.getString(R.string.package_apptoolkit_android)));
-        promotedApps.add(new PromotedApp(
-                R.drawable.ic_code,
-                R.string.qr_scanner_name,
-                R.string.qr_scanner_description,
-                application.getString(R.string.package_qr_scanner)));
+        homeRepository.fetchPromotedApps(apps -> {
+            if (apps.isEmpty()) {
+                promotedApps.postValue(apps);
+                return;
+            }
+            int startIndex = (int) ((System.currentTimeMillis() / (24L * 60 * 60 * 1000)) % apps.size());
+            List<PromotedApp> rotated = new ArrayList<>();
+            for (int i = 0; i < Math.min(4, apps.size()); i++) {
+                rotated.add(apps.get((startIndex + i) % apps.size()));
+            }
+            promotedApps.postValue(rotated);
+        });
     }
 
     /**
@@ -87,7 +79,7 @@ public class HomeViewModel extends AndroidViewModel {
     /**
      * List of apps to promote on the Home screen.
      */
-    public List<PromotedApp> getPromotedApps() {
+    public LiveData<List<PromotedApp>> getPromotedApps() {
         return promotedApps;
     }
 


### PR DESCRIPTION
## Summary
- fetch promoted apps from remote JSON
- rotate apps daily and display them
- load promotional icons from the web

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684979c1ce68832dad7dddb9e920aab6