### PR TITLE
Add more home tips

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -403,6 +403,16 @@
         <item>Implement RecyclerView for smooth scrolling lists.</item>
         <item>Use Material Design 3 components for a modern look.</item>
         <item>Profile your app regularly to track performance.</item>
+        <item>Keep layouts organized by extracting reusable components.</item>
+        <item>Use string resources for all text to simplify localization.</item>
+        <item>Optimize images with WebP to reduce APK size.</item>
+        <item>Enable ProGuard to shrink and obfuscate release builds.</item>
+        <item>Prefer Compose for new UI if targeting modern devices.</item>
+        <item>Take advantage of LiveData and ViewModel for reactive UIs.</item>
+        <item>Use WorkManager for reliable background tasks.</item>
+        <item>Utilize GitHub Actions for automated build checks.</item>
+        <item>Test your app on different screen sizes with the emulator.</item>
+        <item>Keep dependencies updated for the latest features and fixes.</item>
     </string-array>
     <string name="other_apps_title">More apps by the developer</string>
 </resources>


### PR DESCRIPTION
## Summary
- expand the `daily_tips` list with extra tips for the Home screen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498a303584832d9c37ce861e3712a1