### PR TITLE
Handle ScrollView focus clearing

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeFragment.java
@@ -48,6 +48,9 @@ public class HomeFragment extends Fragment {
     @Override
     public void onDestroyView() {
         super.onDestroyView();
+        if (binding != null) {
+            binding.scrollView.clearFocus();
+        }
         binding = null;
     }
 
@@ -67,6 +70,8 @@ public class HomeFragment extends Fragment {
     private void setupPromotions(LayoutInflater inflater) {
         ViewGroup container = binding.promotedAppsContainer;
         homeViewModel.getPromotedApps().observe(getViewLifecycleOwner(), apps -> {
+            binding.scrollView.clearFocus();
+            container.clearFocus();
             container.removeAllViews();
             for (com.d4rk.androidtutorials.java.data.model.PromotedApp app : apps) {
                 com.d4rk.androidtutorials.java.databinding.PromotedAppItemBinding itemBinding =


### PR DESCRIPTION
## Summary
- clear `scrollView` focus when destroying HomeFragment view
- clear focus before removing promoted app views to avoid stale references

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498a85c8cc832d827d70a466fb055c