### PR TITLE
Fix missing WebViewActivity alias

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -115,6 +115,10 @@
             android:exported="false"
             android:label="@string/web_view"
             android:parentActivityName=".ui.screens.android.lessons.views.web.WebViewActivity" />
+        <activity-alias
+            android:name="com.d4rk.androidtutorials.java.ui.android.webviews.WebViewActivity"
+            android:exported="false"
+            android:targetActivity=".ui.screens.android.lessons.views.web.WebViewActivity" />
         <activity
             android:name=".ui.screens.android.lessons.progress.progressbar.ProgressBarActivity"
             android:exported="false"


### PR DESCRIPTION
## Summary
- add an `activity-alias` for the old `WebViewActivity` path

## Testing
- `./gradlew testDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498bdd0480832d8aed877d06edca31