### PR TITLE
Implement persistent consent switches

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/settings/SettingsActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/settings/SettingsActivity.java
@@ -32,6 +32,7 @@ public class SettingsActivity extends AppCompatActivity
         edgeToEdgeDelegate.applyEdgeToEdge(binding.container);
 
         settingsViewModel = new ViewModelProvider(this).get(SettingsViewModel.class);
+        settingsViewModel.applyConsent();
 
         getSupportFragmentManager().beginTransaction()
                 .replace(R.id.settings, new SettingsFragment())

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/settings/SettingsViewModel.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/settings/SettingsViewModel.java
@@ -35,4 +35,8 @@ public class SettingsViewModel extends AndroidViewModel {
     public SharedPreferences getSharedPreferences() {
         return settingsRepository.getSharedPreferences();
     }
+
+    public void applyConsent() {
+        settingsRepository.applyConsent();
+    }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/settings/repository/SettingsRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/settings/repository/SettingsRepository.java
@@ -6,6 +6,9 @@ import android.content.SharedPreferences;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.core.os.LocaleListCompat;
 import androidx.preference.PreferenceManager;
+import com.google.firebase.analytics.FirebaseAnalytics;
+import java.util.EnumMap;
+import java.util.Map;
 
 import com.d4rk.androidtutorials.java.R;
 
@@ -76,7 +79,37 @@ public class SettingsRepository {
             applyTheme();
         } else if (key.equals(context.getString(R.string.key_language))) {
             applyLanguage();
+        } else if (key.equals(context.getString(R.string.key_consent_analytics)) ||
+                key.equals(context.getString(R.string.key_consent_ad_storage)) ||
+                key.equals(context.getString(R.string.key_consent_ad_user_data)) ||
+                key.equals(context.getString(R.string.key_consent_ad_personalization))) {
+            applyConsent();
         }
+    }
+
+    /** Apply Firebase consent settings from preferences */
+    public void applyConsent() {
+        boolean analytics = sharedPreferences.getBoolean(
+                context.getString(R.string.key_consent_analytics), true);
+        boolean adStorage = sharedPreferences.getBoolean(
+                context.getString(R.string.key_consent_ad_storage), true);
+        boolean adUserData = sharedPreferences.getBoolean(
+                context.getString(R.string.key_consent_ad_user_data), true);
+        boolean adPersonalization = sharedPreferences.getBoolean(
+                context.getString(R.string.key_consent_ad_personalization), true);
+
+        Map<FirebaseAnalytics.ConsentType, FirebaseAnalytics.ConsentStatus> map =
+                new EnumMap<>(FirebaseAnalytics.ConsentType.class);
+        map.put(FirebaseAnalytics.ConsentType.ANALYTICS_STORAGE,
+                analytics ? FirebaseAnalytics.ConsentStatus.GRANTED : FirebaseAnalytics.ConsentStatus.DENIED);
+        map.put(FirebaseAnalytics.ConsentType.AD_STORAGE,
+                adStorage ? FirebaseAnalytics.ConsentStatus.GRANTED : FirebaseAnalytics.ConsentStatus.DENIED);
+        map.put(FirebaseAnalytics.ConsentType.AD_USER_DATA,
+                adUserData ? FirebaseAnalytics.ConsentStatus.GRANTED : FirebaseAnalytics.ConsentStatus.DENIED);
+        map.put(FirebaseAnalytics.ConsentType.AD_PERSONALIZATION,
+                adPersonalization ? FirebaseAnalytics.ConsentStatus.GRANTED : FirebaseAnalytics.ConsentStatus.DENIED);
+
+        FirebaseAnalytics.getInstance(context).setConsent(map);
     }
 
     public SharedPreferences getSharedPreferences() {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/startup/StartupActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/startup/StartupActivity.java
@@ -2,6 +2,8 @@ package com.d4rk.androidtutorials.java.ui.screens.startup;
 
 import android.Manifest;
 import android.content.Intent;
+import android.content.SharedPreferences;
+import androidx.preference.PreferenceManager;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -33,6 +35,8 @@ public class StartupActivity extends AppCompatActivity {
         com.d4rk.androidtutorials.java.databinding.ActivityStartupBinding binding = ActivityStartupBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
+        applyStoredConsent();
+
         startupViewModel = new ViewModelProvider(this).get(StartupViewModel.class);
 
         consentInformation = UserMessagingPlatform.getConsentInformation(this);
@@ -50,7 +54,7 @@ public class StartupActivity extends AppCompatActivity {
                                 formError -> updateFirebaseConsent(false, false, false, false)
                         );
                     } else if (consentInformation.getConsentStatus() == ConsentInformation.ConsentStatus.OBTAINED) {
-                        updateFirebaseConsent(true, true, true, true);
+                        applyStoredConsent();
                     }
                 },
                 formError -> {}
@@ -82,6 +86,15 @@ public class StartupActivity extends AppCompatActivity {
     private void proceedToMainActivity() {
         startActivity(new Intent(this, MainActivity.class));
         finish();
+    }
+
+    private void applyStoredConsent() {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        boolean analytics = prefs.getBoolean(getString(R.string.key_consent_analytics), true);
+        boolean adStorage = prefs.getBoolean(getString(R.string.key_consent_ad_storage), true);
+        boolean adUserData = prefs.getBoolean(getString(R.string.key_consent_ad_user_data), true);
+        boolean adPersonalization = prefs.getBoolean(getString(R.string.key_consent_ad_personalization), true);
+        updateFirebaseConsent(analytics, adStorage, adUserData, adPersonalization);
     }
 
     private void updateFirebaseConsent(boolean analytics,

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/startup/dialogs/ConsentDialogFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/startup/dialogs/ConsentDialogFragment.java
@@ -3,6 +3,8 @@ package com.d4rk.androidtutorials.java.ui.screens.startup.dialogs;
 import android.app.Dialog;
 import android.os.Bundle;
 import android.view.LayoutInflater;
+import android.content.SharedPreferences;
+import androidx.preference.PreferenceManager;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -30,11 +32,17 @@ public class ConsentDialogFragment extends DialogFragment {
     public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
         DialogConsentBinding binding = DialogConsentBinding.inflate(LayoutInflater.from(requireContext()));
 
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         boolean defaultChecked = !BuildConfig.DEBUG;
-        binding.checkAnalyticsStorage.setChecked(defaultChecked);
-        binding.checkAdStorage.setChecked(defaultChecked);
-        binding.checkAdUserData.setChecked(defaultChecked);
-        binding.checkAdPersonalization.setChecked(defaultChecked);
+        boolean analytics = prefs.getBoolean(getString(R.string.key_consent_analytics), defaultChecked);
+        boolean adStorage = prefs.getBoolean(getString(R.string.key_consent_ad_storage), defaultChecked);
+        boolean adUserData = prefs.getBoolean(getString(R.string.key_consent_ad_user_data), defaultChecked);
+        boolean adPersonalization = prefs.getBoolean(getString(R.string.key_consent_ad_personalization), defaultChecked);
+
+        binding.checkAnalyticsStorage.setChecked(analytics);
+        binding.checkAdStorage.setChecked(adStorage);
+        binding.checkAdUserData.setChecked(adUserData);
+        binding.checkAdPersonalization.setChecked(adPersonalization);
 
         setCancelable(false);
 
@@ -43,13 +51,20 @@ public class ConsentDialogFragment extends DialogFragment {
                 .setView(binding.getRoot())
                 .setCancelable(false)
                 .setPositiveButton(android.R.string.ok, (dialog, which) -> {
+                    boolean a = binding.checkAnalyticsStorage.isChecked();
+                    boolean b = binding.checkAdStorage.isChecked();
+                    boolean c = binding.checkAdUserData.isChecked();
+                    boolean d = binding.checkAdPersonalization.isChecked();
+
+                    prefs.edit()
+                            .putBoolean(getString(R.string.key_consent_analytics), a)
+                            .putBoolean(getString(R.string.key_consent_ad_storage), b)
+                            .putBoolean(getString(R.string.key_consent_ad_user_data), c)
+                            .putBoolean(getString(R.string.key_consent_ad_personalization), d)
+                            .apply();
+
                     if (listener != null) {
-                        listener.onConsentSet(
-                                binding.checkAnalyticsStorage.isChecked(),
-                                binding.checkAdStorage.isChecked(),
-                                binding.checkAdUserData.isChecked(),
-                                binding.checkAdPersonalization.isChecked()
-                        );
+                        listener.onConsentSet(a, b, c, d);
                     }
                 })
                 .create();

--- a/app/src/main/res/values/keys.xml
+++ b/app/src/main/res/values/keys.xml
@@ -14,4 +14,8 @@
     <string name="key_device_info" translatable="false">device_info</string>
     <string name="key_open_source_licenses" translatable="false">open_source_licenses</string>
     <string name="key_feedback" translatable="false">feedback</string>
+    <string name="key_consent_analytics" translatable="false">consent_analytics_storage</string>
+    <string name="key_consent_ad_storage" translatable="false">consent_ad_storage</string>
+    <string name="key_consent_ad_user_data" translatable="false">consent_ad_user_data</string>
+    <string name="key_consent_ad_personalization" translatable="false">consent_ad_personalization</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -396,6 +396,7 @@
     <string name="ad_storage">Ad storage</string>
     <string name="ad_user_data">Ad user data</string>
     <string name="ad_personalization">Ad personalization</string>
+    <string name="consent_settings">Consent settings</string>
     <string name="tip_of_the_day">Tip of the Day</string>
     <string-array name="daily_tips">
         <item>Use ConstraintLayout to create responsive UIs.</item>

--- a/app/src/main/res/xml/preferences_settings.xml
+++ b/app/src/main/res/xml/preferences_settings.xml
@@ -106,6 +106,25 @@
                 android:action="android.intent.action.VIEW"
                 android:data="https://www.gnu.org/licenses/gpl-3.0" />
         </androidx.preference.Preference>
+        <androidx.preference.PreferenceCategory
+            app:title="@string/consent_settings">
+            <androidx.preference.SwitchPreferenceCompat
+                app:defaultValue="true"
+                app:key="@string/key_consent_analytics"
+                app:title="@string/analytics_storage" />
+            <androidx.preference.SwitchPreferenceCompat
+                app:defaultValue="true"
+                app:key="@string/key_consent_ad_storage"
+                app:title="@string/ad_storage" />
+            <androidx.preference.SwitchPreferenceCompat
+                app:defaultValue="true"
+                app:key="@string/key_consent_ad_user_data"
+                app:title="@string/ad_user_data" />
+            <androidx.preference.SwitchPreferenceCompat
+                app:defaultValue="true"
+                app:key="@string/key_consent_ad_personalization"
+                app:title="@string/ad_personalization" />
+        </androidx.preference.PreferenceCategory>
     </androidx.preference.PreferenceCategory>
     <androidx.preference.PreferenceCategory
         app:icon="@drawable/ic_about"


### PR DESCRIPTION
## Summary
- remove outdated consent mode readme section
- add SharedPreferences keys for consent toggles
- show consent switches in settings
- persist consent choices in ConsentDialog
- apply saved consent at startup and when settings change

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68499b9c82dc832db4c301ea67e65d76