### PR TITLE
Refactor consent handling

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/main/MainActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/main/MainActivity.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
+import android.view.View;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.IntentSenderRequest;
@@ -35,6 +36,7 @@ import com.d4rk.androidtutorials.java.ui.screens.startup.StartupActivity;
 import com.d4rk.androidtutorials.java.ui.screens.startup.StartupViewModel;
 import com.d4rk.androidtutorials.java.ui.screens.support.SupportActivity;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
+import com.d4rk.androidtutorials.java.utils.ConsentUtils;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.MobileAds;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
@@ -154,8 +156,13 @@ public class MainActivity extends AppCompatActivity {
 
                 ((BottomNavigationView) mBinding.navView).setLabelVisibilityMode(visibilityMode);
                 if (mBinding.adView != null) {
-                    MobileAds.initialize(this);
-                    mBinding.adView.loadAd(new AdRequest.Builder().build());
+                    if (ConsentUtils.canShowAds(this)) {
+                        MobileAds.initialize(this);
+                        mBinding.adView.setVisibility(View.VISIBLE);
+                        mBinding.adView.loadAd(new AdRequest.Builder().build());
+                    } else {
+                        mBinding.adView.setVisibility(View.GONE);
+                    }
                 }
             } else {
                 edgeToEdgeDelegate.applyEdgeToEdge(mBinding.container);
@@ -237,6 +244,18 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         super.onResume();
+        ConsentUtils.applyStoredConsent(this);
+        if (mBinding.adView != null) {
+            if (ConsentUtils.canShowAds(this)) {
+                if (mBinding.adView.getVisibility() != View.VISIBLE) {
+                    MobileAds.initialize(this);
+                    mBinding.adView.setVisibility(View.VISIBLE);
+                    mBinding.adView.loadAd(new AdRequest.Builder().build());
+                }
+            } else {
+                mBinding.adView.setVisibility(View.GONE);
+            }
+        }
         AppUsageNotificationsManager appUsageNotificationsManager = new AppUsageNotificationsManager(this);
         appUsageNotificationsManager.scheduleAppUsageCheck();
         appUpdateNotificationsManager.checkAndSendUpdateNotification();

--- a/app/src/main/java/com/d4rk/androidtutorials/java/utils/ConsentUtils.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/utils/ConsentUtils.java
@@ -1,0 +1,47 @@
+package com.d4rk.androidtutorials.java.utils;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.preference.PreferenceManager;
+
+import com.d4rk.androidtutorials.java.R;
+import com.google.firebase.analytics.FirebaseAnalytics;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+public class ConsentUtils {
+
+    public static void applyStoredConsent(Context context) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        boolean analytics = prefs.getBoolean(context.getString(R.string.key_consent_analytics), true);
+        boolean adStorage = prefs.getBoolean(context.getString(R.string.key_consent_ad_storage), true);
+        boolean adUserData = prefs.getBoolean(context.getString(R.string.key_consent_ad_user_data), true);
+        boolean adPersonalization = prefs.getBoolean(context.getString(R.string.key_consent_ad_personalization), true);
+        updateFirebaseConsent(context, analytics, adStorage, adUserData, adPersonalization);
+    }
+
+    public static void updateFirebaseConsent(Context context,
+                                             boolean analytics,
+                                             boolean adStorage,
+                                             boolean adUserData,
+                                             boolean adPersonalization) {
+        Map<FirebaseAnalytics.ConsentType, FirebaseAnalytics.ConsentStatus> consentMap =
+                new EnumMap<>(FirebaseAnalytics.ConsentType.class);
+        consentMap.put(FirebaseAnalytics.ConsentType.ANALYTICS_STORAGE,
+                analytics ? FirebaseAnalytics.ConsentStatus.GRANTED : FirebaseAnalytics.ConsentStatus.DENIED);
+        consentMap.put(FirebaseAnalytics.ConsentType.AD_STORAGE,
+                adStorage ? FirebaseAnalytics.ConsentStatus.GRANTED : FirebaseAnalytics.ConsentStatus.DENIED);
+        consentMap.put(FirebaseAnalytics.ConsentType.AD_USER_DATA,
+                adUserData ? FirebaseAnalytics.ConsentStatus.GRANTED : FirebaseAnalytics.ConsentStatus.DENIED);
+        consentMap.put(FirebaseAnalytics.ConsentType.AD_PERSONALIZATION,
+                adPersonalization ? FirebaseAnalytics.ConsentStatus.GRANTED : FirebaseAnalytics.ConsentStatus.DENIED);
+        FirebaseAnalytics.getInstance(context).setConsent(consentMap);
+    }
+
+    public static boolean canShowAds(Context context) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        return prefs.getBoolean(context.getString(R.string.key_consent_ad_storage), true);
+    }
+}


### PR DESCRIPTION
## Summary
- centralize consent logic in new `ConsentUtils`
- use the helper in StartupActivity
- respect stored consent in MainActivity and hide ads when needed

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849adf3da64832da958da7432183968