### PR TITLE
Fix WebView example JS support

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/views/web/WebViewActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/views/web/WebViewActivity.java
@@ -39,6 +39,8 @@ public class WebViewActivity extends AppCompatActivity {
         webView.loadUrl("https://d4rk7355608.github.io/profile/#home");
         WebSettings webSettings = webView.getSettings();
         webSettings.setJavaScriptEnabled(true);
+        webSettings.setDomStorageEnabled(true);
+        webSettings.setJavaScriptCanOpenWindowsAutomatically(true);
     }
 
     private void setupFloatingButton() {

--- a/app/src/main/res/raw/text_webview_java.txt
+++ b/app/src/main/res/raw/text_webview_java.txt
@@ -1,6 +1,7 @@
 // Import the necessary classes and libraries
 import android.content.Intent;
 import android.os.Bundle;
+import android.webkit.WebSettings;
 import androidx.appcompat.app.AppCompatActivity;
 
 // This class extends AppCompatActivity and represents the main activity of an Android app
@@ -19,6 +20,10 @@ public class MainActivity extends AppCompatActivity {
         setContentView(binding.getRoot());
 
         // Load a URL in the web view in the layout
+        WebSettings webSettings = binding.webView.getSettings();
+        webSettings.setJavaScriptEnabled(true);
+        webSettings.setDomStorageEnabled(true);
+        webSettings.setJavaScriptCanOpenWindowsAutomatically(true);
         binding.webView.loadUrl("https://d4rk7355608.github.io/profile/#home");
     }
 }


### PR DESCRIPTION
## Summary
- enable DOM storage and window opening for WebView example
- update the Java snippet to match the new settings

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ae4a79c4832da566a969c0083a7c