### PR TITLE
Add Firebase prefs and consent icons

### DIFF
--- a/app/src/main/res/values/keys.xml
+++ b/app/src/main/res/values/keys.xml
@@ -10,7 +10,9 @@
     <string name="default_value_language" translatable="false">en</string>
     <string name="key_monospace_font" translatable="false">monospace_font</string>
     <string name="key_notifications_settings" translatable="false">notifications_settings</string>
-    <string name="key_firebase" translatable="false">firebase</string>
+    <string name="key_firebase_crashlytics" translatable="false">firebase_crashlytics</string>
+    <string name="key_firebase_analytics" translatable="false">firebase_analytics</string>
+    <string name="key_firebase_performance" translatable="false">firebase_performance</string>
     <string name="key_device_info" translatable="false">device_info</string>
     <string name="key_open_source_licenses" translatable="false">open_source_licenses</string>
     <string name="key_feedback" translatable="false">feedback</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -248,6 +248,9 @@
     <string name="notification_settings">Notification settings</string>
     <string name="advanced">Advanced</string>
     <string name="firebase">Firebase</string>
+    <string name="firebase_crashlytics">Firebase Crashlytics</string>
+    <string name="firebase_analytics">Firebase Analytics</string>
+    <string name="firebase_performance">Firebase Performance</string>
     <string name="privacy_and_security">Privacy and security</string>
     <string name="privacy_policy">Privacy policy</string>
     <string name="terms_of_service">Terms of service</string>
@@ -316,6 +319,9 @@
     <string name="summary_preference_permissions_foreground_service">Allows the app to create and use services that run in the foreground, giving them priority over other background processes and improving performance and reliability.</string>
     <string name="summary_preference_settings_language">Set application language.</string>
     <string name="summary_preference_settings_firebase">This let us collect information about app performance and crash logs.</string>
+    <string name="summary_preference_settings_firebase_crashlytics">Collect crash reports to help fix issues.</string>
+    <string name="summary_preference_settings_firebase_analytics">Gathers usage data for app improvement.</string>
+    <string name="summary_preference_settings_firebase_performance">Measures app performance for optimization.</string>
     <string name="summary_preference_android_studio_start">Learn the base of how to start a new Android Studio project, how to configure, how to set package, API levels and many more…</string>
     <string name="summary_preference_android_studio_shortcuts">Android Studio includes keyboard shortcuts for many common actions. Keep in mind, because Android Studio is based on IntelliJ IDEA, you can find additional shortcuts in the IntelliJ IDEA keymap reference documentation.</string>
     <string name="summary_preference_android_studio_history_of_android">Learn about the history of Android, from its beta release in 2007 to becoming the world\'s most popular mobile operating system. Discover the features that make Android unique and the benefits of using Android Studio to develop your apps with Java.</string>
@@ -398,6 +404,10 @@
     <string name="ad_user_data">Ad user data</string>
     <string name="ad_personalization">Ad personalization</string>
     <string name="consent_settings">Consent settings</string>
+    <string name="summary_consent_analytics_storage">Allows collection of anonymous usage statistics.</string>
+    <string name="summary_consent_ad_storage">Permits storing ad data on your device.</string>
+    <string name="summary_consent_ad_user_data">Allows sharing user data for ads.</string>
+    <string name="summary_consent_ad_personalization">Enables personalized ad recommendations.</string>
     <string name="tip_of_the_day">Tip of the Day</string>
     <string-array name="daily_tips">
         <item>Use ConstraintLayout to create responsive UIs.</item>

--- a/app/src/main/res/xml/preferences_settings.xml
+++ b/app/src/main/res/xml/preferences_settings.xml
@@ -54,14 +54,26 @@
             app:title="@string/notification_settings" />
     </androidx.preference.PreferenceCategory>
     <androidx.preference.PreferenceCategory
-        app:icon="@drawable/ic_build_tinted"
-        app:title="@string/advanced">
+        app:icon="@drawable/ic_firebase"
+        app:title="@string/firebase">
         <androidx.preference.SwitchPreferenceCompat
             app:defaultValue="true"
-            app:icon="@drawable/ic_firebase"
-            app:key="@string/key_firebase"
-            app:summary="@string/summary_preference_settings_firebase"
-            app:title="@string/firebase" />
+            app:icon="@drawable/ic_crashlytics"
+            app:key="@string/key_firebase_crashlytics"
+            app:summary="@string/summary_preference_settings_firebase_crashlytics"
+            app:title="@string/firebase_crashlytics" />
+        <androidx.preference.SwitchPreferenceCompat
+            app:defaultValue="true"
+            app:icon="@drawable/ic_analytics"
+            app:key="@string/key_firebase_analytics"
+            app:summary="@string/summary_preference_settings_firebase_analytics"
+            app:title="@string/firebase_analytics" />
+        <androidx.preference.SwitchPreferenceCompat
+            app:defaultValue="true"
+            app:icon="@drawable/ic_performance"
+            app:key="@string/key_firebase_performance"
+            app:summary="@string/summary_preference_settings_firebase_performance"
+            app:title="@string/firebase_performance" />
     </androidx.preference.PreferenceCategory>
     <androidx.preference.PreferenceCategory
         app:icon="@drawable/ic_safety_check_tinted"
@@ -110,19 +122,27 @@
             app:title="@string/consent_settings">
             <androidx.preference.SwitchPreferenceCompat
                 app:defaultValue="true"
+                app:icon="@drawable/ic_analytics"
                 app:key="@string/key_consent_analytics"
+                app:summary="@string/summary_consent_analytics_storage"
                 app:title="@string/analytics_storage" />
             <androidx.preference.SwitchPreferenceCompat
                 app:defaultValue="true"
+                app:icon="@drawable/ic_ad_storage"
                 app:key="@string/key_consent_ad_storage"
+                app:summary="@string/summary_consent_ad_storage"
                 app:title="@string/ad_storage" />
             <androidx.preference.SwitchPreferenceCompat
                 app:defaultValue="true"
+                app:icon="@drawable/ic_user_data"
                 app:key="@string/key_consent_ad_user_data"
+                app:summary="@string/summary_consent_ad_user_data"
                 app:title="@string/ad_user_data" />
             <androidx.preference.SwitchPreferenceCompat
                 app:defaultValue="true"
+                app:icon="@drawable/ic_personalization"
                 app:key="@string/key_consent_ad_personalization"
+                app:summary="@string/summary_consent_ad_personalization"
                 app:title="@string/ad_personalization" />
         </androidx.preference.PreferenceCategory>
     </androidx.preference.PreferenceCategory>


### PR DESCRIPTION
## Summary
- replace Advanced category with Firebase services
- add Crashlytics, Analytics and Performance switches
- add icons and summaries for consent options
- add keys and strings for new prefs

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849afb669d0832d990ae305f5a96265