### PR TITLE
Fix Play Store Intent crash

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/repository/HomeRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/repository/HomeRepository.java
@@ -43,9 +43,7 @@ public class HomeRepository {
      */
     public Intent getPlayStoreIntent() {
         String playStoreUrl = "https://play.google.com/store/apps/details?id=" + BuildConfig.APPLICATION_ID;
-        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(playStoreUrl));
-        intent.setPackage("com.android.vending");
-        return intent;
+        return buildPlayStoreIntent(playStoreUrl);
     }
 
     /**
@@ -53,9 +51,20 @@ public class HomeRepository {
      */
     public Intent getAppPlayStoreIntent(String packageName) {
         String url = "https://play.google.com/store/apps/details?id=" + packageName;
-        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-        intent.setPackage("com.android.vending");
-        return intent;
+        return buildPlayStoreIntent(url);
+    }
+
+    /**
+     * Builds an intent that opens a Play Store url if the Google Play app is
+     * installed, otherwise falls back to a generic ACTION_VIEW intent.
+     */
+    private Intent buildPlayStoreIntent(String url) {
+        Intent playStoreIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+        playStoreIntent.setPackage("com.android.vending");
+        if (playStoreIntent.resolveActivity(context.getPackageManager()) != null) {
+            return playStoreIntent;
+        }
+        return new Intent(Intent.ACTION_VIEW, Uri.parse(url));
     }
 
     /**


### PR DESCRIPTION
## Summary
- handle missing Play Store gracefully

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851499e50ec832d837f1d4ff5129ede