### PR TITLE
Integrate CodeView for highlighted previews

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -93,4 +93,5 @@ dependencies {
     implementation libs.lottie
     implementation libs.library
     implementation libs.materialratingbar.library
+    implementation libs.codeview
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ads/managers/AppOpenAd.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ads/managers/AppOpenAd.java
@@ -19,6 +19,7 @@ import com.google.android.gms.ads.FullScreenContentCallback;
 import com.google.android.gms.ads.LoadAdError;
 import com.google.android.gms.ads.MobileAds;
 import com.google.android.gms.ads.appopen.AppOpenAd.AppOpenAdLoadCallback;
+import io.github.kbiakov.codeview.classifier.CodeProcessor;
 
 import java.util.Date;
 
@@ -30,6 +31,7 @@ public class AppOpenAd extends Application implements ActivityLifecycleCallbacks
     @Override
     public void onCreate() {
         super.onCreate();
+        CodeProcessor.init(this);
         this.registerActivityLifecycleCallbacks(this);
         MobileAds.initialize(this, initializationStatus -> {
         });

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/buttons/tabs/ButtonsTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/buttons/tabs/ButtonsTabCodeFragment.java
@@ -17,6 +17,7 @@ import com.d4rk.androidtutorials.java.databinding.FragmentSameCodeBinding;
 import com.google.android.gms.ads.AdRequest;
 import com.d4rk.androidtutorials.java.utils.FontManager;
 import android.util.Log;
+import io.github.kbiakov.codeview.adapters.Options;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -40,7 +41,10 @@ public class ButtonsTabCodeFragment extends Fragment {
             while ((line = reader.readLine()) != null) {
                 builder.append(line).append('\n');
             }
-            binding.textViewCode.setText(builder.toString());
+            Options options = Options.Default.get(requireContext())
+                    .withLanguage("java")
+                    .withCode(builder.toString());
+            binding.codeView.setOptions(options);
         } catch (IOException e) {
             Log.e("ButtonsTabCode", "Error reading code", e);
         }
@@ -53,6 +57,7 @@ public class ButtonsTabCodeFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
-        binding.textViewCode.setTypeface(monospaceFont);
+        binding.codeView.getOptions().withFont(monospaceFont);
+        binding.codeView.updateOptions(binding.codeView.getOptions());
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/progress/progressbar/tabs/ProgressBarTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/progress/progressbar/tabs/ProgressBarTabCodeFragment.java
@@ -17,6 +17,7 @@ import com.d4rk.androidtutorials.java.databinding.FragmentCodeBinding;
 import com.google.android.gms.ads.AdRequest;
 import com.d4rk.androidtutorials.java.utils.FontManager;
 import android.util.Log;
+import io.github.kbiakov.codeview.adapters.Options;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -40,7 +41,10 @@ public class ProgressBarTabCodeFragment extends Fragment {
             while ((line = reader.readLine()) != null) {
                 builder.append(line).append('\n');
             }
-            binding.textView.setText(builder.toString());
+            Options options = Options.Default.get(requireContext())
+                    .withLanguage("java")
+                    .withCode(builder.toString());
+            binding.codeView.setOptions(options);
         } catch (IOException e) {
             Log.e("ProgressBarTabCode", "Error reading code", e);
         }
@@ -52,6 +56,7 @@ public class ProgressBarTabCodeFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
-        binding.textView.setTypeface(monospaceFont);
+        binding.codeView.getOptions().withFont(monospaceFont);
+        binding.codeView.updateOptions(binding.codeView.getOptions());
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/tabs/CodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/tabs/CodeFragment.java
@@ -18,6 +18,8 @@ import com.d4rk.androidtutorials.java.databinding.FragmentCodeBinding;
 import com.d4rk.androidtutorials.java.utils.FontManager;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.MobileAds;
+import io.github.kbiakov.codeview.CodeView;
+import io.github.kbiakov.codeview.adapters.Options;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -60,7 +62,8 @@ public class CodeFragment extends Fragment {
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
-        binding.textView.setTypeface(monospaceFont);
+        binding.codeView.getOptions().withFont(monospaceFont);
+        binding.codeView.updateOptions(binding.codeView.getOptions());
     }
 
     private void loadCode() {
@@ -71,10 +74,13 @@ public class CodeFragment extends Fragment {
             while ((line = reader.readLine()) != null) {
                 builder.append(line).append('\n');
             }
-            binding.textView.setText(builder.toString());
+            Options options = Options.Default.get(requireContext())
+                    .withLanguage("java")
+                    .withCode(builder.toString());
+            binding.codeView.setOptions(options);
         } catch (IOException e) {
             Log.e("Android Code Fragment", "Error loading code from resource ID: " + codeResId, e);
-            binding.textView.setText(R.string.error_loading_code);
+            binding.codeView.setCode(getString(R.string.error_loading_code));
         }
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/tabs/LayoutFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/tabs/LayoutFragment.java
@@ -17,6 +17,7 @@ import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.FragmentLayoutBinding;
 import com.d4rk.androidtutorials.java.utils.FontManager;
 import com.google.android.gms.ads.AdRequest;
+import io.github.kbiakov.codeview.adapters.Options;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -59,7 +60,8 @@ public class LayoutFragment extends Fragment {
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
-        binding.textView.setTypeface(monospaceFont);
+        binding.codeView.getOptions().withFont(monospaceFont);
+        binding.codeView.updateOptions(binding.codeView.getOptions());
     }
 
     private void loadLayout() {
@@ -70,10 +72,13 @@ public class LayoutFragment extends Fragment {
             while ((line = reader.readLine()) != null) {
                 builder.append(line).append('\n');
             }
-            binding.textView.setText(builder.toString());
+            Options options = Options.Default.get(requireContext())
+                    .withLanguage("xml")
+                    .withCode(builder.toString());
+            binding.codeView.setOptions(options);
         } catch (IOException e) {
             Log.e("LayoutFragment", "Error loading layout", e);
-            binding.textView.setText(R.string.error_loading_layout);
+            binding.codeView.setCode(getString(R.string.error_loading_layout));
         }
     }
 }

--- a/app/src/main/res/layout/fragment_code.xml
+++ b/app/src/main/res/layout/fragment_code.xml
@@ -19,14 +19,12 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/text_view"
+            <io.github.kbiakov.codeview.CodeView
+                android:id="@+id/code_view"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:padding="16dp"
-                android:textIsSelectable="true"
-                app:fontFamily="@font/font_audiowide"
-                tools:ignore="SpeakableTextPresentCheck" />
+                app:fontFamily="@font/font_audiowide" />
         </me.zhanghai.android.fastscroll.FastScrollScrollView>
     </com.google.android.material.card.MaterialCardView>
 

--- a/app/src/main/res/layout/fragment_layout.xml
+++ b/app/src/main/res/layout/fragment_layout.xml
@@ -19,14 +19,12 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/text_view"
+            <io.github.kbiakov.codeview.CodeView
+                android:id="@+id/code_view"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:padding="16dp"
-                android:textIsSelectable="true"
-                app:fontFamily="@font/font_audiowide"
-                tools:ignore="SpeakableTextPresentCheck" />
+                app:fontFamily="@font/font_audiowide" />
         </me.zhanghai.android.fastscroll.FastScrollScrollView>
     </com.google.android.material.card.MaterialCardView>
 

--- a/app/src/main/res/layout/fragment_same_code.xml
+++ b/app/src/main/res/layout/fragment_same_code.xml
@@ -39,15 +39,13 @@
                     android:padding="16dp"
                     app:layout_constraintTop_toBottomOf="@id/text_view_warning" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/text_view_code"
+                <io.github.kbiakov.codeview.CodeView
+                    android:id="@+id/code_view"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:padding="16dp"
-                    android:textIsSelectable="true"
                     app:fontFamily="@font/font_audiowide"
-                    app:layout_constraintTop_toBottomOf="@id/divider"
-                    tools:ignore="SpeakableTextPresentCheck" />
+                    app:layout_constraintTop_toBottomOf="@id/divider" />
             </androidx.constraintlayout.widget.ConstraintLayout>
         </me.zhanghai.android.fastscroll.FastScrollScrollView>
     </com.google.android.material.card.MaterialCardView>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ coreKtx = "1.16.0"
 material = "1.12.0"
 multidex = "2.0.1"
 playServicesAds = "24.4.0"
+codeview = "1.3.2"
 
 [libraries]
 aboutlibraries = { module = "com.mikepenz:aboutlibraries", version.ref = "aboutlibraries" }
@@ -54,3 +55,4 @@ materialratingbar-library = { module = "me.zhanghai.android.materialratingbar:li
 play-services-ads = { module = "com.google.android.gms:play-services-ads", version.ref = "playServicesAds" }
 review = { module = "com.google.android.play:review", version.ref = "review" }
 volley = { module = "com.android.volley:volley", version.ref = "volley" }
+codeview = { module = "com.github.kbiakov:CodeView-Android", version.ref = "codeview" }


### PR DESCRIPTION
## Summary
- add CodeView dependency
- initialize CodeProcessor in `AppOpenAd`
- swap `MaterialTextView` with `CodeView` in code preview layouts
- update fragments to configure `CodeView`

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3b093774832daa07d79aed4b57f1