### PR TITLE
Fix CodeView not displaying code

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/relative/tabs/RelativeLayoutTabLayoutFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/relative/tabs/RelativeLayoutTabLayoutFragment.java
@@ -17,6 +17,7 @@ import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.FragmentLayoutBinding;
 import com.d4rk.androidtutorials.java.utils.FontManager;
 import com.google.android.gms.ads.AdRequest;
+import io.github.kbiakov.codeview.adapters.Options;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -40,7 +41,10 @@ public class RelativeLayoutTabLayoutFragment extends Fragment {
             while ((line = reader.readLine()) != null) {
                 builder.append(line).append('\n');
             }
-            //binding.textView.setText(builder.toString()); // FIXME: Cannot resolve symbol 'textView'
+            Options options = Options.Default.get(requireContext())
+                    .withLanguage("xml")
+                    .withCode(builder.toString());
+            binding.codeView.setOptions(options);
         } catch (IOException e) {
             Log.e("RelativeLayoutTab", "Error reading layout text", e);
         }
@@ -52,6 +56,7 @@ public class RelativeLayoutTabLayoutFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
-        //binding.textView.setTypeface(monospaceFont);// FIXME: Cannot resolve symbol 'textView'
+        binding.codeView.getOptions().withFont(monospaceFont);
+        binding.codeView.updateOptions(binding.codeView.getOptions());
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/table/tabs/TableLayoutTabLayoutFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/table/tabs/TableLayoutTabLayoutFragment.java
@@ -17,6 +17,7 @@ import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.FragmentLayoutBinding;
 import com.d4rk.androidtutorials.java.utils.FontManager;
 import com.google.android.gms.ads.AdRequest;
+import io.github.kbiakov.codeview.adapters.Options;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -40,7 +41,10 @@ public class TableLayoutTabLayoutFragment extends Fragment {
             while ((line = reader.readLine()) != null) {
                 builder.append(line).append('\n');
             }
-            //binding.textView.setText(builder.toString());// FIXME: Cannot resolve symbol 'textView'
+            Options options = Options.Default.get(requireContext())
+                    .withLanguage("xml")
+                    .withCode(builder.toString());
+            binding.codeView.setOptions(options);
         } catch (IOException e) {
             Log.e("TableLayoutTab", "Error reading layout", e);
         }
@@ -52,6 +56,7 @@ public class TableLayoutTabLayoutFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
-        //binding.textView.setTypeface(monospaceFont); // FIXME: Cannot resolve symbol 'textView'
+        binding.codeView.getOptions().withFont(monospaceFont);
+        binding.codeView.updateOptions(binding.codeView.getOptions());
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/views/images/tabs/ImagesTabLayoutFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/views/images/tabs/ImagesTabLayoutFragment.java
@@ -17,6 +17,7 @@ import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.FragmentLayoutBinding;
 import com.d4rk.androidtutorials.java.utils.FontManager;
 import com.google.android.gms.ads.AdRequest;
+import io.github.kbiakov.codeview.adapters.Options;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -40,7 +41,10 @@ public class ImagesTabLayoutFragment extends Fragment {
             while ((line = reader.readLine()) != null) {
                 builder.append(line).append('\n');
             }
-            //binding.textView.setText(builder.toString()); // FIXME: Cannot resolve symbol 'textView'
+            Options options = Options.Default.get(requireContext())
+                    .withLanguage("xml")
+                    .withCode(builder.toString());
+            binding.codeView.setOptions(options);
         } catch (IOException e) {
             Log.e("ImagesTab", "Error reading layout", e);
         }
@@ -52,6 +56,7 @@ public class ImagesTabLayoutFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
-        //binding.textView.setTypeface(monospaceFont); // FIXME: Cannot resolve symbol 'textView'
+        binding.codeView.getOptions().withFont(monospaceFont);
+        binding.codeView.updateOptions(binding.codeView.getOptions());
     }
 }


### PR DESCRIPTION
## Summary
- use CodeView in layout lesson fragments
- apply code and font options so code snippets render

## Testing
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_685e405d1fec832d825da05376c584cd