### PR TITLE
Add missing CodeView integrations

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/viewbinding/ViewBindingTutorialActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/viewbinding/ViewBindingTutorialActivity.java
@@ -14,6 +14,7 @@ import com.d4rk.androidtutorials.java.databinding.ActivityViewBindingTutorialBin
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 import com.google.android.gms.ads.AdRequest;
 import com.d4rk.androidtutorials.java.utils.FontManager;
+import com.d4rk.androidtutorials.java.utils.CodeHighlighter;
 import android.util.Log;
 
 import java.io.BufferedReader;
@@ -43,19 +44,39 @@ public class ViewBindingTutorialActivity extends AppCompatActivity {
                 startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://developer.android.com/topic/libraries/view-binding#java"))));
 
         InputStream bindingGradle = getResources().openRawResource(R.raw.text_binding_gradle);
-        binding.bindingText.setText(readTextFromInputStream(bindingGradle));
+        binding.codeViewBindingGradle.setText(readTextFromInputStream(bindingGradle));
+        CodeHighlighter.applyJavaTheme(binding.codeViewBindingGradle);
 
         InputStream bindingActivity = getResources().openRawResource(R.raw.text_binding_activity);
-        binding.bindingActivitiesText.setText(readTextFromInputStream(bindingActivity));
+        binding.codeViewBindingActivities.setText(readTextFromInputStream(bindingActivity));
+        CodeHighlighter.applyJavaTheme(binding.codeViewBindingActivities);
 
         InputStream bindingFragment = getResources().openRawResource(R.raw.text_binding_fragment);
-        binding.bindingFragmentsText.setText(readTextFromInputStream(bindingFragment));
+        binding.codeViewBindingFragments.setText(readTextFromInputStream(bindingFragment));
+        CodeHighlighter.applyJavaTheme(binding.codeViewBindingFragments);
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
         Typeface monospaceFont = FontManager.getMonospaceFont(this, prefs);
-        binding.bindingText.setTypeface(monospaceFont);
-        binding.bindingActivitiesText.setTypeface(monospaceFont);
-        binding.bindingFragmentsText.setTypeface(monospaceFont);
+        binding.codeViewBindingGradle.setTypeface(monospaceFont);
+        binding.codeViewBindingGradle.setLineNumberTextSize(32f);
+        binding.codeViewBindingGradle.setHorizontallyScrolling(false);
+        binding.codeViewBindingGradle.setKeyListener(null);
+        binding.codeViewBindingGradle.setCursorVisible(false);
+        binding.codeViewBindingGradle.setTextIsSelectable(true);
+
+        binding.codeViewBindingActivities.setTypeface(monospaceFont);
+        binding.codeViewBindingActivities.setLineNumberTextSize(32f);
+        binding.codeViewBindingActivities.setHorizontallyScrolling(false);
+        binding.codeViewBindingActivities.setKeyListener(null);
+        binding.codeViewBindingActivities.setCursorVisible(false);
+        binding.codeViewBindingActivities.setTextIsSelectable(true);
+
+        binding.codeViewBindingFragments.setTypeface(monospaceFont);
+        binding.codeViewBindingFragments.setLineNumberTextSize(32f);
+        binding.codeViewBindingFragments.setHorizontallyScrolling(false);
+        binding.codeViewBindingFragments.setKeyListener(null);
+        binding.codeViewBindingFragments.setCursorVisible(false);
+        binding.codeViewBindingFragments.setTextIsSelectable(true);
     }
 
     private String readTextFromInputStream(InputStream inputStream) {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/buttons/tabs/ButtonsTabLayoutFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/buttons/tabs/ButtonsTabLayoutFragment.java
@@ -16,8 +16,9 @@ import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.FragmentButtonsLayoutBinding;
 import com.google.android.gms.ads.AdRequest;
 import com.d4rk.androidtutorials.java.utils.FontManager;
+import com.d4rk.androidtutorials.java.utils.CodeHighlighter;
+import com.amrdeveloper.codeview.CodeView;
 import android.util.Log;
-import com.google.android.material.textview.MaterialTextView;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,7 +29,7 @@ import java.util.Map;
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
 public class ButtonsTabLayoutFragment extends Fragment {
-    private final Map<Integer, MaterialTextView> buttonXMLResources = new HashMap<>();
+    private final Map<Integer, CodeView> buttonXMLResources = new HashMap<>();
     private FragmentButtonsLayoutBinding binding;
 
     @Override
@@ -36,33 +37,34 @@ public class ButtonsTabLayoutFragment extends Fragment {
         binding = FragmentButtonsLayoutBinding.inflate(inflater, container, false);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
         binding.adView.loadAd(new AdRequest.Builder().build());
-        buttonXMLResources.put(R.raw.text_button_normal_xml, binding.textViewButtonNormalXml);
-        buttonXMLResources.put(R.raw.text_button_outlined_xml, binding.textViewButtonOutlinedXml);
-        buttonXMLResources.put(R.raw.text_button_elevated_xml, binding.textViewButtonElevatedXml);
-        buttonXMLResources.put(R.raw.text_button_normal_icon_xml, binding.textViewButtonNormalIconXml);
-        buttonXMLResources.put(R.raw.text_button_outlined_icon_xml, binding.textViewButtonOutlinedIconXml);
-        buttonXMLResources.put(R.raw.text_button_elevated_icon_xml, binding.textViewButtonElevatedIconXml);
-        buttonXMLResources.put(R.raw.text_extended_floating_button_primary_xml, binding.textViewExtendedFloatingButtonPrimaryXml);
-        buttonXMLResources.put(R.raw.text_extended_floating_button_secondary_xml, binding.textViewExtendedFloatingButtonSecondaryXml);
-        buttonXMLResources.put(R.raw.text_extended_floating_button_surface_xml, binding.textViewExtendedFloatingButtonSurfaceXml);
-        buttonXMLResources.put(R.raw.text_extended_floating_button_tertiary_xml, binding.textViewExtendedFloatingButtonTertiaryXml);
-        buttonXMLResources.put(R.raw.text_extended_floating_button_primary_icon_xml, binding.textViewExtendedFloatingButtonPrimaryIconXml);
-        buttonXMLResources.put(R.raw.text_extended_floating_button_secondary_icon_xml, binding.textViewExtendedFloatingButtonSecondaryIconXml);
-        buttonXMLResources.put(R.raw.text_extended_floating_button_surface_icon_xml, binding.textViewExtendedFloatingButtonSurfaceIconXml);
-        buttonXMLResources.put(R.raw.text_extended_floating_button_tertiary_icon_xml, binding.textViewExtendedFloatingButtonTertiaryIconXml);
-        buttonXMLResources.put(R.raw.text_floating_button_primary_xml, binding.textViewFloatingButtonPrimaryXml);
-        buttonXMLResources.put(R.raw.text_floating_button_secondary_xml, binding.textViewFloatingButtonSecondaryXml);
-        buttonXMLResources.put(R.raw.text_floating_button_surface_xml, binding.textViewFloatingButtonSurfaceXml);
-        buttonXMLResources.put(R.raw.text_floating_button_tertiary_xml, binding.textViewFloatingButtonTertiaryXml);
-        for (Map.Entry<Integer, MaterialTextView> entry : buttonXMLResources.entrySet()) {
+        buttonXMLResources.put(R.raw.text_button_normal_xml, binding.codeViewButtonNormalXml);
+        buttonXMLResources.put(R.raw.text_button_outlined_xml, binding.codeViewButtonOutlinedXml);
+        buttonXMLResources.put(R.raw.text_button_elevated_xml, binding.codeViewButtonElevatedXml);
+        buttonXMLResources.put(R.raw.text_button_normal_icon_xml, binding.codeViewButtonNormalIconXml);
+        buttonXMLResources.put(R.raw.text_button_outlined_icon_xml, binding.codeViewButtonOutlinedIconXml);
+        buttonXMLResources.put(R.raw.text_button_elevated_icon_xml, binding.codeViewButtonElevatedIconXml);
+        buttonXMLResources.put(R.raw.text_extended_floating_button_primary_xml, binding.codeViewExtendedFloatingButtonPrimaryXml);
+        buttonXMLResources.put(R.raw.text_extended_floating_button_secondary_xml, binding.codeViewExtendedFloatingButtonSecondaryXml);
+        buttonXMLResources.put(R.raw.text_extended_floating_button_surface_xml, binding.codeViewExtendedFloatingButtonSurfaceXml);
+        buttonXMLResources.put(R.raw.text_extended_floating_button_tertiary_xml, binding.codeViewExtendedFloatingButtonTertiaryXml);
+        buttonXMLResources.put(R.raw.text_extended_floating_button_primary_icon_xml, binding.codeViewExtendedFloatingButtonPrimaryIconXml);
+        buttonXMLResources.put(R.raw.text_extended_floating_button_secondary_icon_xml, binding.codeViewExtendedFloatingButtonSecondaryIconXml);
+        buttonXMLResources.put(R.raw.text_extended_floating_button_surface_icon_xml, binding.codeViewExtendedFloatingButtonSurfaceIconXml);
+        buttonXMLResources.put(R.raw.text_extended_floating_button_tertiary_icon_xml, binding.codeViewExtendedFloatingButtonTertiaryIconXml);
+        buttonXMLResources.put(R.raw.text_floating_button_primary_xml, binding.codeViewFloatingButtonPrimaryXml);
+        buttonXMLResources.put(R.raw.text_floating_button_secondary_xml, binding.codeViewFloatingButtonSecondaryXml);
+        buttonXMLResources.put(R.raw.text_floating_button_surface_xml, binding.codeViewFloatingButtonSurfaceXml);
+        buttonXMLResources.put(R.raw.text_floating_button_tertiary_xml, binding.codeViewFloatingButtonTertiaryXml);
+        for (Map.Entry<Integer, CodeView> entry : buttonXMLResources.entrySet()) {
             Integer resourceId = entry.getKey();
-            MaterialTextView textView = entry.getValue();
+            CodeView codeView = entry.getValue();
             try (InputStream inputStream = getResources().openRawResource(resourceId)) {
                 byte[] bytes = new byte[inputStream.available()];
                 int result = inputStream.read(bytes);
                 if (result != -1) {
                     String text = new String(bytes, StandardCharsets.UTF_8);
-                    textView.setText(text);
+                    codeView.setText(text);
+                    CodeHighlighter.applyXmlTheme(codeView);
                 }
             } catch (IOException e) {
                 Log.e("ButtonsTab", "Error reading button resource", e);
@@ -76,23 +78,13 @@ public class ButtonsTabLayoutFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
-        binding.textViewButtonNormalXml.setTypeface(monospaceFont);
-        binding.textViewButtonOutlinedXml.setTypeface(monospaceFont);
-        binding.textViewButtonElevatedXml.setTypeface(monospaceFont);
-        binding.textViewButtonNormalIconXml.setTypeface(monospaceFont);
-        binding.textViewButtonOutlinedIconXml.setTypeface(monospaceFont);
-        binding.textViewButtonElevatedIconXml.setTypeface(monospaceFont);
-        binding.textViewExtendedFloatingButtonPrimaryXml.setTypeface(monospaceFont);
-        binding.textViewExtendedFloatingButtonSecondaryXml.setTypeface(monospaceFont);
-        binding.textViewExtendedFloatingButtonSurfaceXml.setTypeface(monospaceFont);
-        binding.textViewExtendedFloatingButtonTertiaryXml.setTypeface(monospaceFont);
-        binding.textViewExtendedFloatingButtonPrimaryIconXml.setTypeface(monospaceFont);
-        binding.textViewExtendedFloatingButtonSecondaryIconXml.setTypeface(monospaceFont);
-        binding.textViewExtendedFloatingButtonSurfaceIconXml.setTypeface(monospaceFont);
-        binding.textViewExtendedFloatingButtonTertiaryIconXml.setTypeface(monospaceFont);
-        binding.textViewFloatingButtonPrimaryXml.setTypeface(monospaceFont);
-        binding.textViewFloatingButtonSecondaryXml.setTypeface(monospaceFont);
-        binding.textViewFloatingButtonSurfaceXml.setTypeface(monospaceFont);
-        binding.textViewFloatingButtonTertiaryXml.setTypeface(monospaceFont);
+        for (CodeView codeView : buttonXMLResources.values()) {
+            codeView.setTypeface(monospaceFont);
+            codeView.setLineNumberTextSize(32f);
+            codeView.setHorizontallyScrolling(false);
+            codeView.setKeyListener(null);
+            codeView.setCursorVisible(false);
+            codeView.setTextIsSelectable(true);
+        }
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/clocks/clock/tabs/ClockTabLayoutFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/clocks/clock/tabs/ClockTabLayoutFragment.java
@@ -6,7 +6,7 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.TextView;
+import com.amrdeveloper.codeview.CodeView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -17,6 +17,7 @@ import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.FragmentClockLayoutBinding;
 import com.google.android.gms.ads.AdRequest;
 import com.d4rk.androidtutorials.java.utils.FontManager;
+import com.d4rk.androidtutorials.java.utils.CodeHighlighter;
 import android.util.Log;
 
 import java.io.ByteArrayOutputStream;
@@ -33,13 +34,13 @@ public class ClockTabLayoutFragment extends Fragment {
         binding = FragmentClockLayoutBinding.inflate(inflater, container, false);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
         binding.adView.loadAd(new AdRequest.Builder().build());
-        setTextView(binding.textViewDigitalClockXml, R.raw.text_clock_digital_xml);
-        setTextView(binding.textViewTextClockXml, R.raw.text_clock_xml);
-        setTextView(binding.textViewAnalogClockXml, R.raw.text_clock_analog_xml);
+        setCodeView(binding.codeViewDigitalClockXml, R.raw.text_clock_digital_xml);
+        setCodeView(binding.codeViewTextClockXml, R.raw.text_clock_xml);
+        setCodeView(binding.codeViewAnalogClockXml, R.raw.text_clock_analog_xml);
         return binding.getRoot();
     }
 
-    private void setTextView(TextView textView, int rawResource) {
+    private void setCodeView(CodeView codeView, int rawResource) {
         try (InputStream inputStream = getResources().openRawResource(rawResource)) {
             ByteArrayOutputStream result = new ByteArrayOutputStream();
             byte[] buffer = new byte[1024];
@@ -48,7 +49,8 @@ public class ClockTabLayoutFragment extends Fragment {
                 result.write(buffer, 0, length);
             }
             String text = result.toString();
-            textView.setText(text);
+            codeView.setText(text);
+            CodeHighlighter.applyXmlTheme(codeView);
         } catch (IOException e) {
             Log.e("ClockTab", "Error reading clock layout", e);
         }
@@ -59,8 +61,25 @@ public class ClockTabLayoutFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
-        binding.textViewDigitalClockXml.setTypeface(monospaceFont);
-        binding.textViewTextClockXml.setTypeface(monospaceFont);
-        binding.textViewAnalogClockXml.setTypeface(monospaceFont);
+        binding.codeViewDigitalClockXml.setTypeface(monospaceFont);
+        binding.codeViewDigitalClockXml.setLineNumberTextSize(32f);
+        binding.codeViewDigitalClockXml.setHorizontallyScrolling(false);
+        binding.codeViewDigitalClockXml.setKeyListener(null);
+        binding.codeViewDigitalClockXml.setCursorVisible(false);
+        binding.codeViewDigitalClockXml.setTextIsSelectable(true);
+
+        binding.codeViewTextClockXml.setTypeface(monospaceFont);
+        binding.codeViewTextClockXml.setLineNumberTextSize(32f);
+        binding.codeViewTextClockXml.setHorizontallyScrolling(false);
+        binding.codeViewTextClockXml.setKeyListener(null);
+        binding.codeViewTextClockXml.setCursorVisible(false);
+        binding.codeViewTextClockXml.setTextIsSelectable(true);
+
+        binding.codeViewAnalogClockXml.setTypeface(monospaceFont);
+        binding.codeViewAnalogClockXml.setLineNumberTextSize(32f);
+        binding.codeViewAnalogClockXml.setHorizontallyScrolling(false);
+        binding.codeViewAnalogClockXml.setKeyListener(null);
+        binding.codeViewAnalogClockXml.setCursorVisible(false);
+        binding.codeViewAnalogClockXml.setTextIsSelectable(true);
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/linear/tabs/LinearLayoutTabLayoutFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/linear/tabs/LinearLayoutTabLayoutFragment.java
@@ -16,6 +16,7 @@ import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.FragmentLinearLayoutLayoutBinding;
 import com.google.android.gms.ads.AdRequest;
 import com.d4rk.androidtutorials.java.utils.FontManager;
+import com.d4rk.androidtutorials.java.utils.CodeHighlighter;
 import android.util.Log;
 
 import java.io.BufferedReader;
@@ -38,7 +39,8 @@ public class LinearLayoutTabLayoutFragment extends Fragment {
             while ((line = readerVertical.readLine()) != null) {
                 verticalBuilder.append(line).append('\n');
             }
-            binding.textViewVerticalXml.setText(verticalBuilder.toString());
+            binding.codeViewVerticalXml.setText(verticalBuilder.toString());
+            CodeHighlighter.applyXmlTheme(binding.codeViewVerticalXml);
         } catch (IOException e) {
             Log.e("LinearLayoutTab", "Error reading vertical layout", e);
         }
@@ -48,7 +50,8 @@ public class LinearLayoutTabLayoutFragment extends Fragment {
             while ((line = readerHorizontal.readLine()) != null) {
                 horizontalBuilder.append(line).append('\n');
             }
-            binding.textViewHorizontalXml.setText(horizontalBuilder.toString());
+            binding.codeViewHorizontalXml.setText(horizontalBuilder.toString());
+            CodeHighlighter.applyXmlTheme(binding.codeViewHorizontalXml);
         } catch (IOException e) {
             Log.e("LinearLayoutTab", "Error reading horizontal layout", e);
         }
@@ -60,7 +63,18 @@ public class LinearLayoutTabLayoutFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
-        binding.textViewVerticalXml.setTypeface(monospaceFont);
-        binding.textViewHorizontalXml.setTypeface(monospaceFont);
+        binding.codeViewVerticalXml.setTypeface(monospaceFont);
+        binding.codeViewVerticalXml.setLineNumberTextSize(32f);
+        binding.codeViewVerticalXml.setHorizontallyScrolling(false);
+        binding.codeViewVerticalXml.setKeyListener(null);
+        binding.codeViewVerticalXml.setCursorVisible(false);
+        binding.codeViewVerticalXml.setTextIsSelectable(true);
+
+        binding.codeViewHorizontalXml.setTypeface(monospaceFont);
+        binding.codeViewHorizontalXml.setLineNumberTextSize(32f);
+        binding.codeViewHorizontalXml.setHorizontallyScrolling(false);
+        binding.codeViewHorizontalXml.setKeyListener(null);
+        binding.codeViewHorizontalXml.setCursorVisible(false);
+        binding.codeViewHorizontalXml.setTextIsSelectable(true);
     }
 }

--- a/app/src/main/res/layout/activity_view_binding_tutorial.xml
+++ b/app/src/main/res/layout/activity_view_binding_tutorial.xml
@@ -62,15 +62,12 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/ad_view">
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/bindingText"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:minWidth="48dp"
-                android:padding="16dp"
-                android:textIsSelectable="true"
-                app:fontFamily="@font/font_audiowide"
-                tools:ignore="SpeakableTextPresentCheck" />
+        <com.amrdeveloper.codeview.CodeView
+            android:id="@+id/code_view_binding_gradle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minWidth="48dp"
+            android:padding="16dp" />
         </com.google.android.material.card.MaterialCardView>
 
         <com.google.android.material.textview.MaterialTextView
@@ -96,15 +93,12 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/bindingActivitiesUseText">
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/bindingActivitiesText"
-                android:layout_width="wrap_content"
+            <com.amrdeveloper.codeview.CodeView
+                android:id="@+id/code_view_binding_activities"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:minWidth="48dp"
-                android:padding="16dp"
-                android:textIsSelectable="true"
-                app:fontFamily="@font/font_audiowide"
-                tools:ignore="SpeakableTextPresentCheck" />
+                android:padding="16dp" />
         </com.google.android.material.card.MaterialCardView>
 
         <com.google.android.material.textview.MaterialTextView
@@ -130,15 +124,12 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/bindingFragmentsUseText">
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/bindingFragmentsText"
-                android:layout_width="wrap_content"
+            <com.amrdeveloper.codeview.CodeView
+                android:id="@+id/code_view_binding_fragments"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:minWidth="48dp"
-                android:padding="16dp"
-                android:textIsSelectable="true"
-                app:fontFamily="@font/font_audiowide"
-                tools:ignore="SpeakableTextPresentCheck" />
+                android:padding="16dp" />
         </com.google.android.material.card.MaterialCardView>
 
         <com.google.android.material.button.MaterialButton

--- a/app/src/main/res/layout/fragment_buttons_layout.xml
+++ b/app/src/main/res/layout/fragment_buttons_layout.xml
@@ -31,14 +31,11 @@
                     android:padding="16dp"
                     android:text="@string/button_normal" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/text_view_button_normal_xml"
+                <com.amrdeveloper.codeview.CodeView
+                    android:id="@+id/code_view_button_normal_xml"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="16dp"
-                    android:textIsSelectable="true"
-                    app:fontFamily="@font/font_audiowide"
-                    tools:ignore="SpeakableTextPresentCheck" />
+                    android:padding="16dp" />
 
                 <com.google.android.material.textview.MaterialTextView
                     style="@style/TextAppearance.Material3.HeadlineSmall"
@@ -47,14 +44,11 @@
                     android:padding="16dp"
                     android:text="@string/button_outlined" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/text_view_button_outlined_xml"
+                <com.amrdeveloper.codeview.CodeView
+                    android:id="@+id/code_view_button_outlined_xml"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="16dp"
-                    android:textIsSelectable="true"
-                    app:fontFamily="@font/font_audiowide"
-                    tools:ignore="SpeakableTextPresentCheck" />
+                    android:padding="16dp" />
 
                 <com.google.android.material.textview.MaterialTextView
                     style="@style/TextAppearance.Material3.HeadlineSmall"
@@ -63,14 +57,11 @@
                     android:padding="16dp"
                     android:text="@string/button_elevated" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/text_view_button_elevated_xml"
+                <com.amrdeveloper.codeview.CodeView
+                    android:id="@+id/code_view_button_elevated_xml"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="16dp"
-                    android:textIsSelectable="true"
-                    app:fontFamily="@font/font_audiowide"
-                    tools:ignore="SpeakableTextPresentCheck" />
+                    android:padding="16dp" />
 
                 <com.google.android.material.textview.MaterialTextView
                     style="@style/TextAppearance.Material3.HeadlineSmall"
@@ -79,14 +70,11 @@
                     android:padding="16dp"
                     android:text="@string/button_normal_icon" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/text_view_button_normal_icon_xml"
+                <com.amrdeveloper.codeview.CodeView
+                    android:id="@+id/code_view_button_normal_icon_xml"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="16dp"
-                    android:textIsSelectable="true"
-                    app:fontFamily="@font/font_audiowide"
-                    tools:ignore="SpeakableTextPresentCheck" />
+                    android:padding="16dp" />
 
                 <com.google.android.material.textview.MaterialTextView
                     style="@style/TextAppearance.Material3.HeadlineSmall"
@@ -95,14 +83,11 @@
                     android:padding="16dp"
                     android:text="@string/button_outlined_icon" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/text_view_button_outlined_icon_xml"
+                <com.amrdeveloper.codeview.CodeView
+                    android:id="@+id/code_view_button_outlined_icon_xml"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="16dp"
-                    android:textIsSelectable="true"
-                    app:fontFamily="@font/font_audiowide"
-                    tools:ignore="SpeakableTextPresentCheck" />
+                    android:padding="16dp" />
 
                 <com.google.android.material.textview.MaterialTextView
                     style="@style/TextAppearance.Material3.HeadlineSmall"
@@ -111,14 +96,11 @@
                     android:padding="16dp"
                     android:text="@string/button_elevated_icon" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/text_view_button_elevated_icon_xml"
+                <com.amrdeveloper.codeview.CodeView
+                    android:id="@+id/code_view_button_elevated_icon_xml"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="16dp"
-                    android:textIsSelectable="true"
-                    app:fontFamily="@font/font_audiowide"
-                    tools:ignore="SpeakableTextPresentCheck" />
+                    android:padding="16dp" />
 
                 <com.google.android.material.textview.MaterialTextView
                     style="@style/TextAppearance.Material3.HeadlineSmall"
@@ -127,14 +109,11 @@
                     android:padding="16dp"
                     android:text="@string/extended_floating_button_primary" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/text_view_extended_floating_button_primary_xml"
+                <com.amrdeveloper.codeview.CodeView
+                    android:id="@+id/code_view_extended_floating_button_primary_xml"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="16dp"
-                    android:textIsSelectable="true"
-                    app:fontFamily="@font/font_audiowide"
-                    tools:ignore="SpeakableTextPresentCheck" />
+                    android:padding="16dp" />
 
                 <com.google.android.material.textview.MaterialTextView
                     style="@style/TextAppearance.Material3.HeadlineSmall"
@@ -143,13 +122,11 @@
                     android:padding="16dp"
                     android:text="@string/extended_floating_button_secondary" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/text_view_extended_floating_button_secondary_xml"
+                <com.amrdeveloper.codeview.CodeView
+                    android:id="@+id/code_view_extended_floating_button_secondary_xml"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="16dp"
-                    android:textIsSelectable="true"
-                    app:fontFamily="@font/font_audiowide" />
+                    android:padding="16dp" />
 
                 <com.google.android.material.textview.MaterialTextView
                     style="@style/TextAppearance.Material3.HeadlineSmall"
@@ -158,13 +135,11 @@
                     android:padding="16dp"
                     android:text="@string/extended_floating_button_surface" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/text_view_extended_floating_button_surface_xml"
+                <com.amrdeveloper.codeview.CodeView
+                    android:id="@+id/code_view_extended_floating_button_surface_xml"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="16dp"
-                    android:textIsSelectable="true"
-                    app:fontFamily="@font/font_audiowide" />
+                    android:padding="16dp" />
 
                 <com.google.android.material.textview.MaterialTextView
                     style="@style/TextAppearance.Material3.HeadlineSmall"
@@ -173,13 +148,11 @@
                     android:padding="16dp"
                     android:text="@string/extended_floating_button_tertiary" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/text_view_extended_floating_button_tertiary_xml"
+                <com.amrdeveloper.codeview.CodeView
+                    android:id="@+id/code_view_extended_floating_button_tertiary_xml"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="16dp"
-                    android:textIsSelectable="true"
-                    app:fontFamily="@font/font_audiowide" />
+                    android:padding="16dp" />
 
                 <com.google.android.material.textview.MaterialTextView
                     style="@style/TextAppearance.Material3.HeadlineSmall"
@@ -188,13 +161,11 @@
                     android:padding="16dp"
                     android:text="@string/extended_floating_button_primary_icon" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/text_view_extended_floating_button_primary_icon_xml"
+                <com.amrdeveloper.codeview.CodeView
+                    android:id="@+id/code_view_extended_floating_button_primary_icon_xml"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:padding="16dp"
-                    android:textIsSelectable="true"
-                    app:fontFamily="@font/font_audiowide"
                     app:layout_constraintTop_toBottomOf="@id/text_view_extended_floating_button_primary_icon" />
 
                 <com.google.android.material.textview.MaterialTextView
@@ -204,13 +175,11 @@
                     android:padding="16dp"
                     android:text="@string/extended_floating_button_secondary_icon" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/text_view_extended_floating_button_secondary_icon_xml"
+                <com.amrdeveloper.codeview.CodeView
+                    android:id="@+id/code_view_extended_floating_button_secondary_icon_xml"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="16dp"
-                    android:textIsSelectable="true"
-                    app:fontFamily="@font/font_audiowide" />
+                    android:padding="16dp" />
 
                 <com.google.android.material.textview.MaterialTextView
                     style="@style/TextAppearance.Material3.HeadlineSmall"
@@ -219,13 +188,11 @@
                     android:padding="16dp"
                     android:text="@string/extended_floating_button_surface_icon" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/text_view_extended_floating_button_surface_icon_xml"
+                <com.amrdeveloper.codeview.CodeView
+                    android:id="@+id/code_view_extended_floating_button_surface_icon_xml"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="16dp"
-                    android:textIsSelectable="true"
-                    app:fontFamily="@font/font_audiowide" />
+                    android:padding="16dp" />
 
                 <com.google.android.material.textview.MaterialTextView
                     style="@style/TextAppearance.Material3.HeadlineSmall"
@@ -234,13 +201,11 @@
                     android:padding="16dp"
                     android:text="@string/extended_floating_button_tertiary_icon" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/text_view_extended_floating_button_tertiary_icon_xml"
+                <com.amrdeveloper.codeview.CodeView
+                    android:id="@+id/code_view_extended_floating_button_tertiary_icon_xml"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="16dp"
-                    android:textIsSelectable="true"
-                    app:fontFamily="@font/font_audiowide" />
+                    android:padding="16dp" />
 
                 <com.google.android.material.textview.MaterialTextView
                     style="@style/TextAppearance.Material3.HeadlineSmall"
@@ -249,14 +214,11 @@
                     android:padding="16dp"
                     android:text="@string/floating_button_primary_icon" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/text_view_floating_button_primary_xml"
+                <com.amrdeveloper.codeview.CodeView
+                    android:id="@+id/code_view_floating_button_primary_xml"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="16dp"
-                    android:textIsSelectable="true"
-                    app:fontFamily="@font/font_audiowide"
-                    tools:ignore="SpeakableTextPresentCheck" />
+                    android:padding="16dp" />
 
                 <com.google.android.material.textview.MaterialTextView
                     style="@style/TextAppearance.Material3.HeadlineSmall"
@@ -265,13 +227,11 @@
                     android:padding="16dp"
                     android:text="@string/floating_button_secondary_icon" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/text_view_floating_button_secondary_xml"
+                <com.amrdeveloper.codeview.CodeView
+                    android:id="@+id/code_view_floating_button_secondary_xml"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:padding="16dp"
-                    android:textIsSelectable="true"
-                    app:fontFamily="@font/font_audiowide"
                     app:layout_constraintTop_toBottomOf="@id/text_view_floating_button_secondary" />
 
                 <com.google.android.material.textview.MaterialTextView
@@ -281,13 +241,11 @@
                     android:padding="16dp"
                     android:text="@string/floating_button_surface_icon" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/text_view_floating_button_surface_xml"
+                <com.amrdeveloper.codeview.CodeView
+                    android:id="@+id/code_view_floating_button_surface_xml"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="16dp"
-                    android:textIsSelectable="true"
-                    app:fontFamily="@font/font_audiowide" />
+                    android:padding="16dp" />
 
                 <com.google.android.material.textview.MaterialTextView
                     style="@style/TextAppearance.Material3.HeadlineSmall"
@@ -296,13 +254,11 @@
                     android:padding="16dp"
                     android:text="@string/floating_button_tertiary_icon" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/text_view_floating_button_tertiary_xml"
+                <com.amrdeveloper.codeview.CodeView
+                    android:id="@+id/code_view_floating_button_tertiary_xml"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="16dp"
-                    android:textIsSelectable="true"
-                    app:fontFamily="@font/font_audiowide" />
+                    android:padding="16dp" />
             </androidx.appcompat.widget.LinearLayoutCompat>
         </me.zhanghai.android.fastscroll.FastScrollScrollView>
     </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/fragment_clock_layout.xml
+++ b/app/src/main/res/layout/fragment_clock_layout.xml
@@ -31,13 +31,11 @@
                     android:padding="16dp"
                     android:text="@string/clock_analog" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/text_view_analog_clock_xml"
+                <com.amrdeveloper.codeview.CodeView
+                    android:id="@+id/code_view_analog_clock_xml"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="16dp"
-                    android:textIsSelectable="true"
-                    app:fontFamily="@font/font_audiowide" />
+                    android:padding="16dp" />
 
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/text_view_digital_clock"
@@ -47,13 +45,11 @@
                     android:padding="16dp"
                     android:text="@string/clock_digital" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/text_view_digital_clock_xml"
+                <com.amrdeveloper.codeview.CodeView
+                    android:id="@+id/code_view_digital_clock_xml"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="16dp"
-                    android:textIsSelectable="true"
-                    app:fontFamily="@font/font_audiowide" />
+                    android:padding="16dp" />
 
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/text_view_text_clock"
@@ -63,13 +59,11 @@
                     android:padding="16dp"
                     android:text="@string/clock_text" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/text_view_text_clock_xml"
+                <com.amrdeveloper.codeview.CodeView
+                    android:id="@+id/code_view_text_clock_xml"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:padding="16dp"
-                    android:textIsSelectable="true"
-                    app:fontFamily="@font/font_audiowide"
                     app:layout_constraintTop_toBottomOf="@id/text_view_text_clock" />
             </androidx.appcompat.widget.LinearLayoutCompat>
         </me.zhanghai.android.fastscroll.FastScrollScrollView>

--- a/app/src/main/res/layout/fragment_linear_layout_layout.xml
+++ b/app/src/main/res/layout/fragment_linear_layout_layout.xml
@@ -31,14 +31,11 @@
                     android:padding="16dp"
                     android:text="@string/vertical" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/text_view_vertical_xml"
+                <com.amrdeveloper.codeview.CodeView
+                    android:id="@+id/code_view_vertical_xml"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="16dp"
-                    android:textIsSelectable="true"
-                    app:fontFamily="@font/font_audiowide"
-                    tools:ignore="SpeakableTextPresentCheck" />
+                    android:padding="16dp" />
 
                 <com.google.android.material.textview.MaterialTextView
                     style="@style/TextAppearance.Material3.HeadlineSmall"
@@ -47,14 +44,11 @@
                     android:padding="16dp"
                     android:text="@string/horizontal" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/text_view_horizontal_xml"
+                <com.amrdeveloper.codeview.CodeView
+                    android:id="@+id/code_view_horizontal_xml"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="16dp"
-                    android:textIsSelectable="true"
-                    app:fontFamily="@font/font_audiowide"
-                    tools:ignore="SpeakableTextPresentCheck" />
+                    android:padding="16dp" />
             </androidx.appcompat.widget.LinearLayoutCompat>
         </me.zhanghai.android.fastscroll.FastScrollScrollView>
     </com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
## Summary
- integrate CodeView with View Binding tutorial and apply syntax highlighting
- switch LinearLayout, Buttons and Clock lessons to use CodeView widgets
- highlight XML snippets with `CodeHighlighter` and make them read-only

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e4e6c0e4c832dbe75905b57f7d4e6