### PR TITLE
Ensure consistent CodeView setup

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/viewbinding/ViewBindingTutorialActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/viewbinding/ViewBindingTutorialActivity.java
@@ -44,6 +44,13 @@ public class ViewBindingTutorialActivity extends AppCompatActivity {
         binding.moreAboutViewBindingButton.setOnClickListener(v ->
                 startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://developer.android.com/topic/libraries/view-binding#java"))));
 
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        Typeface monospaceFont = FontManager.getMonospaceFont(this, prefs);
+        CodeViewUtils.applyDefaults(monospaceFont,
+                binding.codeViewBindingGradle,
+                binding.codeViewBindingActivities,
+                binding.codeViewBindingFragments);
+
         InputStream bindingGradle = getResources().openRawResource(R.raw.text_binding_gradle);
         binding.codeViewBindingGradle.setText(readTextFromInputStream(bindingGradle));
         CodeHighlighter.applyJavaTheme(binding.codeViewBindingGradle);
@@ -55,13 +62,6 @@ public class ViewBindingTutorialActivity extends AppCompatActivity {
         InputStream bindingFragment = getResources().openRawResource(R.raw.text_binding_fragment);
         binding.codeViewBindingFragments.setText(readTextFromInputStream(bindingFragment));
         CodeHighlighter.applyJavaTheme(binding.codeViewBindingFragments);
-
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
-        Typeface monospaceFont = FontManager.getMonospaceFont(this, prefs);
-        CodeViewUtils.applyDefaults(monospaceFont,
-                binding.codeViewBindingGradle,
-                binding.codeViewBindingActivities,
-                binding.codeViewBindingFragments);
     }
 
     private String readTextFromInputStream(InputStream inputStream) {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/buttons/tabs/ButtonsTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/buttons/tabs/ButtonsTabCodeFragment.java
@@ -35,6 +35,11 @@ public class ButtonsTabCodeFragment extends Fragment {
         binding = FragmentSameCodeBinding.inflate(inflater, container, false);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
         binding.adView.loadAd(new AdRequest.Builder().build());
+
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
+        Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
+        CodeViewUtils.applyDefaults(monospaceFont, binding.codeView);
+
         StringBuilder builder = new StringBuilder();
         InputStream inputStream = getResources().openRawResource(R.raw.text_buttons_java);
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
@@ -51,11 +56,4 @@ public class ButtonsTabCodeFragment extends Fragment {
         return binding.getRoot();
     }
 
-    @Override
-    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
-        Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
-        CodeViewUtils.applyDefaults(monospaceFont, binding.codeView);
-    }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/buttons/tabs/ButtonsTabLayoutFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/buttons/tabs/ButtonsTabLayoutFragment.java
@@ -38,6 +38,10 @@ public class ButtonsTabLayoutFragment extends Fragment {
         binding = FragmentButtonsLayoutBinding.inflate(inflater, container, false);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
         binding.adView.loadAd(new AdRequest.Builder().build());
+
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
+        Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
+        CodeViewUtils.applyDefaults(monospaceFont, buttonXMLResources.values().toArray(new CodeView[0]));
         buttonXMLResources.put(R.raw.text_button_normal_xml, binding.codeViewButtonNormalXml);
         buttonXMLResources.put(R.raw.text_button_outlined_xml, binding.codeViewButtonOutlinedXml);
         buttonXMLResources.put(R.raw.text_button_elevated_xml, binding.codeViewButtonElevatedXml);
@@ -74,11 +78,4 @@ public class ButtonsTabLayoutFragment extends Fragment {
         return binding.getRoot();
     }
 
-    @Override
-    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
-        Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
-        CodeViewUtils.applyDefaults(monospaceFont, buttonXMLResources.values().toArray(new CodeView[0]));
-    }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/clocks/clock/tabs/ClockTabLayoutFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/clocks/clock/tabs/ClockTabLayoutFragment.java
@@ -35,6 +35,13 @@ public class ClockTabLayoutFragment extends Fragment {
         binding = FragmentClockLayoutBinding.inflate(inflater, container, false);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
         binding.adView.loadAd(new AdRequest.Builder().build());
+
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
+        Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
+        CodeViewUtils.applyDefaults(monospaceFont,
+                binding.codeViewDigitalClockXml,
+                binding.codeViewTextClockXml,
+                binding.codeViewAnalogClockXml);
         setCodeView(binding.codeViewDigitalClockXml, R.raw.text_clock_digital_xml);
         setCodeView(binding.codeViewTextClockXml, R.raw.text_clock_xml);
         setCodeView(binding.codeViewAnalogClockXml, R.raw.text_clock_analog_xml);
@@ -55,16 +62,5 @@ public class ClockTabLayoutFragment extends Fragment {
         } catch (IOException e) {
             Log.e("ClockTab", "Error reading clock layout", e);
         }
-    }
-
-    @Override
-    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
-        Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
-        CodeViewUtils.applyDefaults(monospaceFont,
-                binding.codeViewDigitalClockXml,
-                binding.codeViewTextClockXml,
-                binding.codeViewAnalogClockXml);
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/linear/tabs/LinearLayoutTabLayoutFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/linear/tabs/LinearLayoutTabLayoutFragment.java
@@ -34,6 +34,13 @@ public class LinearLayoutTabLayoutFragment extends Fragment {
         binding = FragmentLinearLayoutLayoutBinding.inflate(inflater, container, false);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
         binding.adView.loadAd(new AdRequest.Builder().build());
+
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
+        Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
+        CodeViewUtils.applyDefaults(monospaceFont,
+                binding.codeViewVerticalXml,
+                binding.codeViewHorizontalXml);
+
         StringBuilder verticalBuilder = new StringBuilder();
         try (BufferedReader readerVertical = new BufferedReader(new InputStreamReader(getResources().openRawResource(R.raw.text_linear_layout_vertical_xml)))) {
             String line;
@@ -57,15 +64,5 @@ public class LinearLayoutTabLayoutFragment extends Fragment {
             Log.e("LinearLayoutTab", "Error reading horizontal layout", e);
         }
         return binding.getRoot();
-    }
-
-    @Override
-    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
-        Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
-        CodeViewUtils.applyDefaults(monospaceFont,
-                binding.codeViewVerticalXml,
-                binding.codeViewHorizontalXml);
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/relative/tabs/RelativeLayoutTabLayoutFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/relative/tabs/RelativeLayoutTabLayoutFragment.java
@@ -35,6 +35,11 @@ public class RelativeLayoutTabLayoutFragment extends Fragment {
         binding = FragmentLayoutBinding.inflate(inflater, container, false);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
         binding.adView.loadAd(new AdRequest.Builder().build());
+
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
+        Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
+        CodeViewUtils.applyDefaults(monospaceFont, binding.codeView);
+
         StringBuilder builder = new StringBuilder();
         InputStream inputStream = getResources().openRawResource(R.raw.text_relative_layout_xml);
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
@@ -50,11 +55,4 @@ public class RelativeLayoutTabLayoutFragment extends Fragment {
         return binding.getRoot();
     }
 
-    @Override
-    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
-        Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
-        CodeViewUtils.applyDefaults(monospaceFont, binding.codeView);
-    }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/table/tabs/TableLayoutTabLayoutFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/table/tabs/TableLayoutTabLayoutFragment.java
@@ -35,6 +35,11 @@ public class TableLayoutTabLayoutFragment extends Fragment {
         binding = FragmentLayoutBinding.inflate(inflater, container, false);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
         binding.adView.loadAd(new AdRequest.Builder().build());
+
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
+        Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
+        CodeViewUtils.applyDefaults(monospaceFont, binding.codeView);
+
         StringBuilder builder = new StringBuilder();
         InputStream inputStream = getResources().openRawResource(R.raw.text_table_layout_xml);
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
@@ -50,11 +55,4 @@ public class TableLayoutTabLayoutFragment extends Fragment {
         return binding.getRoot();
     }
 
-    @Override
-    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
-        Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
-        CodeViewUtils.applyDefaults(monospaceFont, binding.codeView);
-    }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/progress/progressbar/tabs/ProgressBarTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/progress/progressbar/tabs/ProgressBarTabCodeFragment.java
@@ -35,6 +35,11 @@ public class ProgressBarTabCodeFragment extends Fragment {
         binding = FragmentCodeBinding.inflate(inflater, container, false);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
         binding.adView.loadAd(new AdRequest.Builder().build());
+
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
+        Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
+        CodeViewUtils.applyDefaults(monospaceFont, binding.codeView);
+
         StringBuilder builder = new StringBuilder();
         InputStream inputStream = getResources().openRawResource(R.raw.text_progress_bar_java);
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
@@ -50,11 +55,4 @@ public class ProgressBarTabCodeFragment extends Fragment {
         return binding.getRoot();
     }
 
-    @Override
-    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
-        Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
-        CodeViewUtils.applyDefaults(monospaceFont, binding.codeView);
-    }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/progress/progressbar/tabs/ProgressBarTabLayoutFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/progress/progressbar/tabs/ProgressBarTabLayoutFragment.java
@@ -34,6 +34,13 @@ public class ProgressBarTabLayoutFragment extends Fragment {
         binding = FragmentLinearLayoutLayoutBinding.inflate(inflater, container, false);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
         binding.adView.loadAd(new AdRequest.Builder().build());
+
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
+        Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
+        CodeViewUtils.applyDefaults(monospaceFont,
+                binding.codeViewVerticalXml,
+                binding.codeViewHorizontalXml);
+
         StringBuilder verticalBuilder = new StringBuilder();
         try (BufferedReader readerVertical = new BufferedReader(new InputStreamReader(getResources().openRawResource(R.raw.text_progress_bar_xml)))) {
             String line;
@@ -59,13 +66,4 @@ public class ProgressBarTabLayoutFragment extends Fragment {
         return binding.getRoot();
     }
 
-    @Override
-    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
-        Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
-        CodeViewUtils.applyDefaults(monospaceFont,
-                binding.codeViewVerticalXml,
-                binding.codeViewHorizontalXml);
-    }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/views/images/tabs/ImagesTabLayoutFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/views/images/tabs/ImagesTabLayoutFragment.java
@@ -35,6 +35,11 @@ public class ImagesTabLayoutFragment extends Fragment {
         binding = FragmentLayoutBinding.inflate(inflater, container, false);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
         binding.adView.loadAd(new AdRequest.Builder().build());
+
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
+        Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
+        CodeViewUtils.applyDefaults(monospaceFont, binding.codeView);
+
         StringBuilder builder = new StringBuilder();
         InputStream inputStream = getResources().openRawResource(R.raw.text_image_view_xml);
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
@@ -50,11 +55,5 @@ public class ImagesTabLayoutFragment extends Fragment {
         return binding.getRoot();
     }
 
-    @Override
-    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
-        Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
-        CodeViewUtils.applyDefaults(monospaceFont, binding.codeView);
-    }
+
 }


### PR DESCRIPTION
## Summary
- configure `CodeView` widgets with `CodeViewUtils` before applying syntax highlighting
- remove now-empty lifecycle overrides

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f04eea2a4832db67ed199b400464c