### PR TITLE
Fix CI workflow branch

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,9 +2,9 @@ name: Android CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- fix the workflow branch name from `master` to `main`

## Testing
- `./gradlew tasks`
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687971074188832da35dca1cd0c2f123